### PR TITLE
Fix status move crash in main battle system

### DIFF
--- a/src/battle.cpp
+++ b/src/battle.cpp
@@ -79,6 +79,11 @@ void Battle::executeMove(Pokemon &attacker, Pokemon &defender,
 
 int Battle::calculateDamage(const Pokemon &attacker, const Pokemon &defender,
                             const Move &move) const {
+  // Status moves don't deal damage
+  if (move.power <= 0) {
+    return 0;
+  }
+
   int damage = 0;
   if (move.damage_class == "physical") {
     damage = (attacker.attack - defender.defense) + move.power;


### PR DESCRIPTION
- Added power check in calculateDamage to handle status moves properly
- Status moves with power <= 0 now return 0 damage instead of causing crashes
- Resolves bus error when selecting status moves like leech-seed, amnesia, etc.
- Battle system now handles both damaging and status moves correctly