### PR TITLE
Add STAB and Critical Hit mechanics

### DIFF
--- a/src/battle.h
+++ b/src/battle.h
@@ -6,6 +6,7 @@
 #include "type_effectiveness.h"
 #include <iostream>
 #include <memory>
+#include <random>
 
 class Battle {
 public:
@@ -38,10 +39,30 @@ private:
   void displayHealth(const Pokemon &pokemon) const;
   void displayBattleStatus() const;
   bool playerFirst(const Move &playerMove, const Move &opponentMove) const;
+  struct DamageResult {
+    int damage;
+    bool wasCritical;
+    bool hadSTAB;
+  };
+
+  DamageResult calculateDamageWithEffects(const Pokemon &attacker,
+                                          const Pokemon &defender,
+                                          const Move &move) const;
   int calculateDamage(const Pokemon &attacker, const Pokemon &defender,
                       const Move &move) const;
+
+  // Enhanced damage calculation methods
+  bool hasSTAB(const Pokemon &attacker, const Move &move) const;
+  bool isCriticalHit(const Move &move) const;
+  double calculateSTABMultiplier(const Pokemon &attacker,
+                                 const Move &move) const;
+  double calculateCriticalMultiplier(const Move &move) const;
 
   // Input handling
   int getMoveChoice() const;
   int getPokemonChoice() const;
+
+  // Random number generation for critical hits
+  mutable std::mt19937 rng;
+  mutable std::uniform_real_distribution<double> criticalDistribution;
 };


### PR DESCRIPTION
- Implement STAB (Same Type Attack Bonus) - 1.5x damage when move type matches Pokemon type
- Add Critical Hit system - 2x damage with 6.25% base chance (12.5% for high crit moves)
- Create DamageResult struct to track damage modifiers
- Add calculateDamageWithEffects method for comprehensive damage calculation
- Update battle display to show STAB and critical hit messages