### PR TITLE
feat: implement flinch mechanics

### DIFF
--- a/src/battle.cpp
+++ b/src/battle.cpp
@@ -150,6 +150,15 @@ void Battle::executeMove(Pokemon &attacker, Pokemon &defender,
 
     defender.takeDamage(damageResult.damage);
 
+    // Apply flinch effect if move has flinch chance and defender is still alive
+    if (move.flinch_chance > 0 && defender.isAlive()) {
+      auto flinchDistribution = std::uniform_int_distribution<int>(1, 100);
+      if (flinchDistribution(rng) <= move.flinch_chance) {
+        defender.applyStatusCondition(StatusCondition::FLINCH);
+        std::cout << defender.name << " flinched!" << std::endl;
+      }
+    }
+
     // Apply status condition from damage moves
     StatusCondition statusToApply = move.getStatusCondition();
     if (statusToApply != StatusCondition::NONE && move.ailment_chance > 0) {

--- a/src/pokemon.cpp
+++ b/src/pokemon.cpp
@@ -81,7 +81,15 @@ void Pokemon::heal(int amount) {
 }
 
 void Pokemon::applyStatusCondition(StatusCondition newStatus) {
-  // Can't apply status if already has one (except replacing with same type)
+  // Flinch can be applied even if Pokemon has another status condition
+  if (newStatus == StatusCondition::FLINCH) {
+    status = newStatus;
+    status_turns_remaining = 1; // Flinch only lasts 1 turn
+    return;
+  }
+
+  // Can't apply other status if already has one (except replacing with same
+  // type)
   if (hasStatusCondition() && status != newStatus) {
     return;
   }
@@ -103,6 +111,9 @@ void Pokemon::applyStatusCondition(StatusCondition newStatus) {
     break;
   case StatusCondition::NONE:
     status_turns_remaining = 0;
+    break;
+  case StatusCondition::FLINCH:
+    // Already handled above
     break;
   }
 }
@@ -165,6 +176,12 @@ void Pokemon::processStatusCondition() {
     std::cout << name << " is paralyzed!" << std::endl;
     break;
 
+  case StatusCondition::FLINCH:
+    // Flinch automatically clears after 1 turn
+    std::cout << name << " flinched and couldn't move!" << std::endl;
+    clearStatusCondition();
+    break;
+
   case StatusCondition::NONE:
     break;
   }
@@ -177,6 +194,7 @@ bool Pokemon::canAct() const {
   switch (status) {
   case StatusCondition::SLEEP:
   case StatusCondition::FREEZE:
+  case StatusCondition::FLINCH:
     return false;
 
   case StatusCondition::PARALYSIS:
@@ -205,6 +223,8 @@ std::string Pokemon::getStatusConditionName() const {
     return "Asleep";
   case StatusCondition::FREEZE:
     return "Frozen";
+  case StatusCondition::FLINCH:
+    return "Flinched";
   case StatusCondition::NONE:
     return "";
   default:

--- a/src/pokemon.h
+++ b/src/pokemon.h
@@ -8,7 +8,15 @@
 #include <vector>
 
 // Status conditions enum
-enum class StatusCondition { NONE, POISON, BURN, PARALYSIS, SLEEP, FREEZE };
+enum class StatusCondition {
+  NONE,
+  POISON,
+  BURN,
+  PARALYSIS,
+  SLEEP,
+  FREEZE,
+  FLINCH
+};
 
 class Pokemon {
 public:


### PR DESCRIPTION
Features Added:
- Added FLINCH to StatusCondition enum
- Flinch prevents Pokemon from acting for 1 turn only
- Flinch can be applied even if Pokemon has another status
- Automatic flinch clearing after 1 turn
- 30% flinch chance moves: Rock Slide, Headbutt, Bite, etc.
- 20% flinch chance moves: Zen Headbutt, Dragon Rush, etc.
- 10% flinch chance moves: Hyper Fang, Bone Club, etc.

Battle Integration:
- Flinch applied after damage calculation
- Proper status messages and feedback
- Compatible with existing status system