### PR TITLE
Fix unused variable warning in battle.cpp

### DIFF
--- a/src/battle.cpp
+++ b/src/battle.cpp
@@ -267,6 +267,9 @@ void Battle::executeMove(Pokemon &attacker, Pokemon &defender, int moveIndex) {
       if (hadSTAB) {
         std::cout << " " << attacker.name << " gets STAB!";
       }
+      if (wasCritical) {
+        std::cout << " At least one critical hit!";
+      }
       std::cout << std::endl;
     } else if (hadSTAB) {
       std::cout << attacker.name << " gets STAB!" << std::endl;


### PR DESCRIPTION
- Add 'wasCritical' usage to multi-hit move summary
- Now shows 'At least one critical hit\!' for multi-hit moves with crits
- Eliminates compiler warning about unused variable